### PR TITLE
Merge points even if overlapping

### DIFF
--- a/ConnectTheDots.py
+++ b/ConnectTheDots.py
@@ -47,7 +47,7 @@ def run(context):
                 for merge in points[index+1:]:
                     if validatePoint(merge):
                         distance = point.geometry.distanceTo(merge.geometry)
-                        if 0.0 < distance < threshold_distance:
+                        if 0.0 <= distance < threshold_distance:
                             try:
                                 point.merge(merge)
                             except:


### PR DESCRIPTION
Set the script to merge points even if distance between points is equal to 0. If endpoint positions match eactly but otherwise have no constraints applied (for example, the sketch was created by another script such as https://github.com/lukecyca/BoxMaker), overlapping points should now have the coincident constraint applied.